### PR TITLE
fix (setup.sh): Use a base URL of http:// rather than https://

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ if [ $(find $MAGE_ROOT_DIR -maxdepth 0 -type d -empty 2>/dev/null) ]; then
         --dbPass=magento                                    \
         --dbName=magento                                    \
         --useDefaultConfigParams=yes                        \
-        --baseUrl="https://pwa-magento.docker/"
+        --baseUrl="http://pwa-magento.docker/"
 
     chgrp -R 33 $MAGE_ROOT_DIR/media $MAGE_ROOT_DIR/var
     find $MAGE_ROOT_DIR/media $MAGE_ROOT_DIR/var -type d -exec chmod 775 {} +


### PR DESCRIPTION
The docker-compose setup exposes port 80 on a random host port, however the base URL is set to https (and thus 443). This renders the site inaccessible by default.

This commit changes the base URL to http, so that the IP of the container can be added to the hostfile and the site accessed as normal.